### PR TITLE
Refactored model generation to use CamelCase for struct and field nam…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module go-SchemaRestifier
 
 go 1.23
+
+require github.com/iancoleman/strcase v0.3.0

--- a/testdata/user_profile.json
+++ b/testdata/user_profile.json
@@ -1,0 +1,108 @@
+{
+  "table": {
+    "name": "user_profile",
+    "description": "User profile table for schema metaprogramming tool",
+    "columns": [
+      {
+        "name": "user_id",
+        "type": "integer",
+        "primary_key": true,
+        "auto_increment": true,
+        "nullable": false,
+        "struct": {
+          "field_name": "UserID",
+          "field_type": "int",
+          "json_tag": "user_id"
+        },
+        "query": {
+          "select": true,
+          "filter": true,
+          "sort": true
+        }
+      },
+      {
+        "name": "username",
+        "type": "varchar(100)",
+        "nullable": false,
+        "unique": true,
+        "struct": {
+          "field_name": "Username",
+          "field_type": "string",
+          "json_tag": "username"
+        },
+        "query": {
+          "select": true,
+          "filter": true,
+          "sort": false,
+          "search": true
+        }
+      },
+      {
+        "name": "profile_data",
+        "type": "json",
+        "nullable": true,
+        "struct": {
+          "field_name": "ProfileData",
+          "field_type": "object",
+          "json_tag": "profile_data"
+        },
+        "query": {
+          "select": true,
+          "filter": false,
+          "sort": false
+        },
+        "json_data": {
+          "bio": "string",
+          "age": "integer",
+          "settings": {
+            "theme": "string",
+            "notifications": {
+              "email": "bool",
+              "sms": "bool"
+            }
+          },
+          "tags": "[string]"
+        }
+      },
+      {
+        "name": "created_at",
+        "type": "timestamp",
+        "nullable": false,
+        "struct": {
+          "field_name": "CreatedAt",
+          "field_type": "datetime",
+          "json_tag": "created_at"
+        },
+        "query": {
+          "select": true,
+          "filter": false,
+          "sort": true
+        }
+      }
+    ]
+  },
+  "crud": {
+    "create": {
+      "enabled": true,
+      "endpoint": "/user_profile",
+      "auth_required": true
+    },
+    "read": {
+      "enabled": true,
+      "endpoint": "/user_profile",
+      "auth_required": true,
+      "list_supported": true,
+      "single_supported": true
+    },
+    "update": {
+      "enabled": true,
+      "endpoint": "/user_profile/{user_id}",
+      "auth_required": true
+    },
+    "delete": {
+      "enabled": true,
+      "endpoint": "/user_profile/{user_id}",
+      "auth_required": true
+    }
+  }
+}


### PR DESCRIPTION

This pull request introduces improved code generation for struct names and fields by converting them to CamelCase, ensuring better Go naming conventions and consistency. It also adds a new dependency for string case conversion and provides a sample JSON schema for testing. The most important changes are grouped below:

**Code generation improvements:**

* Updated struct and field name generation in `internal/generator/generator.go` to use CamelCase via the `strcase.ToCamel` function, ensuring that generated Go code follows idiomatic naming conventions. This applies to both top-level and nested structs and fields. [[1]](diffhunk://#diff-93b5439df693e891da6c7aef54a4dfc3bd2f00a0aab7cc4d352345ce3c3c4981R88-R99) [[2]](diffhunk://#diff-93b5439df693e891da6c7aef54a4dfc3bd2f00a0aab7cc4d352345ce3c3c4981L196-R207)

**Dependency management:**

* Added the `github.com/iancoleman/strcase` dependency to `go.mod` to support string case conversion for struct and field names.
* Imported the `strcase` package in `internal/generator/generator.go` for use in code generation logic.

**Testing and examples:**

* Added a comprehensive `testdata/user_profile.json` file, providing a sample schema with various column types and CRUD operations to facilitate testing and demonstration of the schema restifier tool.