### PR TITLE
refactor

### DIFF
--- a/internal/datastructures/tree.go
+++ b/internal/datastructures/tree.go
@@ -7,6 +7,8 @@ type Node struct {
 	Fields   []*Fields
 	Children []*Node
 	Mu       sync.Mutex
+	// updatable later
+	Hidden bool
 }
 
 func IsNodeEmpty(n Node) bool {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -108,15 +108,6 @@ func GenerateModel(filePath string, content []parser.Schema) error {
 				traTree, _ := TraverseTreeModel(column.Nestedcolumns, p)
 				nestedStructContent += traTree
 			}
-			//	if len(column.Nestedcolumns) > 0 {
-			//		p := new(string)
-			//		column.Nestedcolumns["...@__root_name__@..."] = column.Name
-			//		nestedthing, _ := ConvertNestedMapToNodeTree(column.Nestedcolumns, &datastructures.Node{}, nil)
-			//		traTree, _ := TraverseTreeModel(&nestedthing, p)
-			//		nestedStructContent += traTree
-			//
-			//	}
-
 		}
 		modelContent += "}\n\n"
 		modelContent += nestedStructContent

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -120,8 +120,6 @@ func GenerateModel(filePath string, content []parser.Schema) error {
 	return nil
 }
 
-// ConvertNestedMapToNodeTree processes a nested map structure and converts it into a tree-like structure using the datastructures.Node type.
-// It recursively traverses the map, creating nodes for each key-value pair and handling nested maps appropriately.
 func TraverseTreeModel(n *datastructures.Node, p *string) (string, error) {
 	if p == nil {
 

--- a/internal/generator/types.go
+++ b/internal/generator/types.go
@@ -2,36 +2,36 @@ package generator
 
 import "strings"
 
-// types represents supported type strings.
-type types string
+// Types represents supported type strings.
+type Types string
 
 const (
-	TypeString      types = "string"
-	TypeInteger     types = "integer"
-	TypeBoolean     types = "boolean"
-	TypeFloat       types = "float"
-	TypeObject      types = "object"
-	TypeArray       types = "array"
-	TypeDate        types = "date"
-	TypeDateTime    types = "datetime"
-	TypeIntArray    types = "[integer]"
-	TypeStringArray types = "[string]"
-	TypeStringVar   types = "varchar(255)"
-	TypeText        types = "text"
-	TypeVarchar     types = "varchar"
-	TypeChar        types = "char"
-	TypeSerial      types = "serial"
-	TypeBigSerial   types = "bigserial"
-	TypeBigInt      types = "bigint"
-	TypeSmallInt    types = "smallint"
-	TypeNumeric     types = "numeric"
-	TypeUUID        types = "uuid"
-	TypeJSONB       types = "jsonb"
-	TypeBytea       types = "bytea"
-	TypeTimestamp   types = "timestamp"
+	TypeString      Types = "string"
+	TypeInteger     Types = "integer"
+	TypeBoolean     Types = "boolean"
+	TypeFloat       Types = "float"
+	TypeObject      Types = "object"
+	TypeArray       Types = "array"
+	TypeDate        Types = "date"
+	TypeDateTime    Types = "datetime"
+	TypeIntArray    Types = "[integer]"
+	TypeStringArray Types = "[string]"
+	TypeStringVar   Types = "varchar(255)"
+	TypeText        Types = "text"
+	TypeVarchar     Types = "varchar"
+	TypeChar        Types = "char"
+	TypeSerial      Types = "serial"
+	TypeBigSerial   Types = "bigserial"
+	TypeBigInt      Types = "bigint"
+	TypeSmallInt    Types = "smallint"
+	TypeNumeric     Types = "numeric"
+	TypeUUID        Types = "uuid"
+	TypeJSONB       Types = "jsonb"
+	TypeBytea       Types = "bytea"
+	TypeTimestamp   Types = "timestamp"
 )
 
-var typeNames = map[types]string{
+var typeNames = map[Types]string{
 	TypeString:      "string",
 	TypeInteger:     "int",
 	TypeBoolean:     "bool",
@@ -58,7 +58,7 @@ var typeNames = map[types]string{
 }
 
 // String returns the string representation of the types value.
-func (t types) String() string {
+func (t Types) String() string {
 	if name, ok := typeNames[t]; ok {
 		return name
 	}
@@ -66,7 +66,7 @@ func (t types) String() string {
 }
 
 // ftypes returns the canonical type or "unknown" if not found.
-func ftypes(s types) types {
+func ftypes(s Types) Types {
 	switch s {
 	case TypeString, TypeInteger, TypeBoolean, TypeFloat, TypeObject, TypeArray, TypeDate, TypeDateTime, TypeChar, TypeSerial, TypeBigSerial, TypeBigInt, TypeSmallInt, TypeNumeric, TypeUUID, TypeJSONB, TypeBytea, TypeTimestamp:
 		return s
@@ -76,7 +76,7 @@ func ftypes(s types) types {
 }
 
 // ParseTypes converts a string to the corresponding types enum value.
-func ParseTypes(s string) (types, bool) {
+func ParseTypes(s string) (Types, bool) {
 	switch {
 	case s == "string":
 		return TypeString, true

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -21,7 +21,6 @@ func JsonDataAlgorithm(content map[string]interface{}, n *datastructures.Node, r
 			typ, _ := m["type"].(string)
 			switch typ {
 			case "object":
-				fmt.Println("Nested map reached with value:", value)
 				newN := new(datastructures.Node)
 				newN.Name = key
 				n.Mu.Lock()

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -37,6 +37,11 @@ func ParseSchema(schemaFilePath string) ([]Schema, error) {
 								desc, _ := colMap["description"].(string)
 								pk, _ := colMap["primary_key"].(bool)
 								nested, _ := colMap["json_data"].(map[string]interface{})
+								queries := make(map[string]bool)
+								for queryType, IsTrue := range colMap["query"].(map[string]interface{}) {
+
+									queries[queryType] = IsTrue.(bool)
+								}
 
 								column := Column{
 									Name:          name,
@@ -44,18 +49,8 @@ func ParseSchema(schemaFilePath string) ([]Schema, error) {
 									Description:   desc,
 									PrimaryKey:    pk,
 									Nestedcolumns: nested,
+									Capabilities:  queries,
 								}
-								//			if nested, ok := colMap["json_data"]; ok {
-								//				if nestedMap, ok := nested.(map[string]interface{}); ok {
-								//					convertedMap := make(map[string][]interface{})
-								//					for k, v := range nestedMap {
-								//						convertedMap[k] = []interface{}{v}
-								//					}
-								//					column.Nestedcolumns = convertedMap
-								//				} else {
-								//					fmt.Println("Invalid nested columns format:", nested)
-								//	}
-								//}
 								*schema.Columns = append(*schema.Columns, column)
 							} else {
 								fmt.Println("Invalid column format:", col)

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -20,5 +20,5 @@ type Column struct {
 	Unique        bool                   `json:"unique,omitempty"`
 	Hidden        bool                   `json:"hidden,omitempty"`
 	Nestedcolumns map[string]interface{} `json:"json_data,omitempty"` // Optional field for nested schemas
-
+	Capabilities  map[string]bool        `json:"query,omitempty"`     // e.g., {"select": true, "filter": false}
 }

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -1,5 +1,10 @@
 package parser
 
+import (
+	"go-SchemaRestifier/internal/datastructures"
+	"strings"
+)
+
 // Package parser provides functionality to parse and handle schemas in a structured format.
 
 // Schema represents the structure of a parsed schema.
@@ -12,13 +17,127 @@ type Schema struct {
 
 // Column represents a single column in a schema.
 type Column struct {
-	Name          string                 `json:"name"`                  // Name of the column
-	Type          string                 `json:"type"`                  // Type of the column (e.g., string, integer, etc.)
-	Description   string                 `json:"description,omitempty"` // Optional description of the column
-	PrimaryKey    bool                   `json:"primary_key,omitempty"` // Indicates if the column is a primary key
-	Nullable      bool                   `json:"nullable,omitempty"`
-	Unique        bool                   `json:"unique,omitempty"`
-	Hidden        bool                   `json:"hidden,omitempty"`
-	Nestedcolumns map[string]interface{} `json:"json_data,omitempty"` // Optional field for nested schemas
-	Capabilities  map[string]bool        `json:"query,omitempty"`     // e.g., {"select": true, "filter": false}
+	Name          string               `json:"name"`                  // Name of the column
+	Type          string               `json:"type"`                  // Type of the column (e.g., string, integer, etc.)
+	Description   string               `json:"description,omitempty"` // Optional description of the column
+	PrimaryKey    bool                 `json:"primary_key,omitempty"` // Indicates if the column is a primary key
+	Nullable      bool                 `json:"nullable,omitempty"`
+	Unique        bool                 `json:"unique,omitempty"`
+	Hidden        bool                 `json:"hidden,omitempty"`
+	Nestedcolumns *datastructures.Node `json:"json_data,omitempty"` // Optional field for nested schemas
+	Capabilities  map[string]bool      `json:"query,omitempty"`     // e.g., {"select": true, "filter": false}
+}
+
+// Types represents supported type strings.
+type Types string
+
+const (
+	TypeString      Types = "string"
+	TypeInteger     Types = "integer"
+	TypeBoolean     Types = "boolean"
+	TypeFloat       Types = "float"
+	TypeObject      Types = "object"
+	TypeArray       Types = "array"
+	TypeDate        Types = "date"
+	TypeDateTime    Types = "datetime"
+	TypeIntArray    Types = "[integer]"
+	TypeStringArray Types = "[string]"
+	TypeStringVar   Types = "varchar(255)"
+	TypeText        Types = "text"
+	TypeVarchar     Types = "varchar"
+	TypeChar        Types = "char"
+	TypeSerial      Types = "serial"
+	TypeBigSerial   Types = "bigserial"
+	TypeBigInt      Types = "bigint"
+	TypeSmallInt    Types = "smallint"
+	TypeNumeric     Types = "numeric"
+	TypeUUID        Types = "uuid"
+	TypeJSONB       Types = "jsonb"
+	TypeBytea       Types = "bytea"
+	TypeTimestamp   Types = "timestamp"
+)
+
+var typeNames = map[Types]string{
+	TypeString:      "string",
+	TypeInteger:     "int",
+	TypeBoolean:     "bool",
+	TypeFloat:       "float64",
+	TypeObject:      "map[string]interface{}",
+	TypeArray:       "[]interface{}",
+	TypeDate:        "date",
+	TypeDateTime:    "datetime",
+	TypeIntArray:    "[]int",
+	TypeStringArray: "[]string",
+	TypeStringVar:   "string",
+	TypeText:        "string",
+	TypeVarchar:     "string",
+	TypeChar:        "string",
+	TypeSerial:      "int",
+	TypeBigSerial:   "int64",
+	TypeBigInt:      "int64",
+	TypeSmallInt:    "int16",
+	TypeNumeric:     "float64",
+	TypeUUID:        "string",
+	TypeJSONB:       "map[string]interface{}",
+	TypeBytea:       "[]byte",
+	TypeTimestamp:   "time.Time",
+}
+
+// String returns the string representation of the types value.
+func (t Types) String() string {
+	if name, ok := typeNames[t]; ok {
+		return name
+	}
+	return "unknown"
+}
+
+// ftypes returns the canonical type or "unknown" if not found.
+func ftypes(s Types) Types {
+	switch s {
+	case TypeString, TypeInteger, TypeBoolean, TypeFloat, TypeObject, TypeArray, TypeDate, TypeDateTime, TypeChar, TypeSerial, TypeBigSerial, TypeBigInt, TypeSmallInt, TypeNumeric, TypeUUID, TypeJSONB, TypeBytea, TypeTimestamp:
+		return s
+	default:
+		return "unknown"
+	}
+}
+
+// ParseTypes converts a string to the corresponding types enum value.
+func ParseTypes(s string) (Types, bool) {
+	switch {
+	case s == "string":
+		return TypeString, true
+	case s == "integer":
+		return TypeInteger, true
+	case s == "bool":
+		return TypeBoolean, true
+	case s == "float64":
+		return TypeFloat, true
+	case s == "map[string]interface{}":
+		return TypeObject, true
+	case s == "[]interface{}":
+		return TypeArray, true
+	case s == "date":
+		return TypeDate, true
+	case s == "datetime":
+		return TypeDateTime, true
+	case s == "[integer]":
+		return TypeIntArray, true
+	case s == "[string]":
+		return TypeStringArray, true
+	case strings.Contains(s, "varchar"):
+		return TypeStringVar, true
+	case s == "text":
+		return TypeText, true
+	case s == "varchar":
+		return TypeVarchar, true
+	case s == "char":
+		return TypeChar, true
+	case s == "serial":
+		return TypeSerial, true
+	case s == "bigserial":
+		return TypeBigSerial, true
+	case s == "timestamp":
+		return TypeTimestamp, true
+	}
+	return "unknown", false
 }

--- a/testdata/data.json
+++ b/testdata/data.json
@@ -9,6 +9,10 @@
         "primary_key": true,
         "auto_increment": true,
         "nullable": false,
+        "unique": true,
+        "index": true,
+        "hidden": false,
+        "default": null,
         "struct": {
           "field_name": "ExampleID",
           "field_type": "int",
@@ -57,7 +61,7 @@
         "type": "json",
         "nullable": true,
         "struct": {
-          "field_name": "ConfigObj",
+          "field_name": "Config",
           "field_type": "object",
           "json_tag": "config"
         },
@@ -67,15 +71,58 @@
           "sort": false
         },
         "json_data": {
-          "color": "string",
-          "size": "integer",
-          "tags": "[string]",
+          "color": {
+            "type": "string",
+            "nullable": false,
+            "unique": true,
+            "index": true,
+            "hidden": false,
+            "default": null
+          },
+          "size": {
+            "type": "integer",
+            "nullable": false,
+            "unique": true,
+            "index": true,
+            "hidden": false,
+            "default": null
+          },
+          "tags": {
+            "type": "[string]",
+            "nullable": false,
+            "unique": true,
+            "index": true,
+            "hidden": false,
+            "default": null
+          },
           "extra": {
-            "foo": "bool",
-            "baz": "[integer]",
+            "type": "object",
+            "foo": {
+              "type": "bool",
+              "nullable": false,
+              "unique": true,
+              "index": true,
+              "hidden": false,
+              "default": null
+            },
+            "baz": {
+              "type": "[integer]",
+              "nullable": false,
+              "unique": true,
+              "index": true,
+              "hidden": false,
+              "default": null
+            },
             "bar": {
-              "nested": "string",
-              "nested_array": "[string]"
+              "type": "object",
+              "nested": {
+                "type": "string",
+                "nullable": false,
+                "unique": true,
+                "index": true,
+                "hidden": false,
+                "default": null
+              }
             }
           }
         }

--- a/testdata/user_profile.json
+++ b/testdata/user_profile.json
@@ -52,16 +52,89 @@
           "sort": false
         },
         "json_data": {
-          "bio": "string",
-          "age": "integer",
+          "bio": {
+            "type": "string",
+            "nullable": false,
+            "unique": false,
+            "index": false,
+            "hidden": false,
+            "default": null
+          },
+          "age": {
+            "type": "integer",
+            "nullable": false,
+            "unique": false,
+            "index": false,
+            "hidden": false,
+            "default": null
+          },
           "settings": {
-            "theme": "string",
+            "type": "object",
+            "theme": {
+              "type": "string",
+              "nullable": false,
+              "unique": false,
+              "index": false,
+              "hidden": false,
+              "default": null
+            },
             "notifications": {
-              "email": "bool",
-              "sms": "bool"
+              "type": "object",
+              "email": {
+                "type": "bool",
+                "nullable": false,
+                "unique": false,
+                "index": false,
+                "hidden": false,
+                "default": null
+              },
+              "sms": {
+                "type": "bool",
+                "nullable": false,
+                "unique": false,
+                "index": false,
+                "hidden": false,
+                "default": null
+              }
             }
           },
-          "tags": "[string]"
+          "tags": {
+            "type": "[string]",
+            "nullable": false,
+            "unique": false,
+            "index": false,
+            "hidden": false,
+            "default": null
+          },
+          "extra": {
+            "type": "object",
+            "is_verified": {
+              "type": "bool",
+              "nullable": false,
+              "unique": false,
+              "index": false,
+              "hidden": false,
+              "default": null
+            },
+            "score": {
+              "type": "integer",
+              "nullable": false,
+              "unique": false,
+              "index": false,
+              "hidden": false,
+              "default": null
+            },
+            "details": {
+              "nested": {
+                "type": "string",
+                "nullable": false,
+                "unique": false,
+                "index": false,
+                "hidden": false,
+                "default": null
+              }
+            }
+          }
         }
       },
       {


### PR DESCRIPTION
This pull request refactors how nested schema data is represented and processed throughout the codebase, moving from a generic map-based approach to a strongly-typed tree structure (`Node`). It also introduces more detailed type handling and expands the schema parsing logic to support richer metadata (such as field capabilities and visibility). The changes affect the parser, generator, data structures, and test data, improving the maintainability and extensibility of schema handling.

**Schema Representation and Parsing Improvements:**

* Changed the `Nestedcolumns` field in the `Column` struct from a generic `map[string]interface{}` to a strongly-typed pointer to a `Node` struct, enabling more robust handling of nested schemas. Added a `Capabilities` field for query capabilities and a `Hidden` flag for visibility control. (`[internal/parser/types.goL22-R142](diffhunk://#diff-8149ccf0b06b32c3267afacb1e628e23fe22107617b3b99a200cd6ca62ddd2bdL22-R142)`)
* Updated the parsing logic in `parser.go` to build nested column trees using the new `JsonDataAlgorithm` function, which recursively constructs a `Node` tree from the detailed JSON schema. This supports richer metadata for each nested field, such as type, nullability, uniqueness, index, hidden, and default value. (`[[1]](diffhunk://#diff-d1655fd776ca5fcf2821d7a478d18e80e68fc75d43a8aabeb5fbb07197c4f3ccL39-L58)`, `[[2]](diffhunk://#diff-d1655fd776ca5fcf2821d7a478d18e80e68fc75d43a8aabeb5fbb07197c4f3ccR5-R52)`)
* Modified the test data files (`data.json`, `user_profile.json`) to use the new nested object format, including explicit metadata for each nested field. (`[[1]](diffhunk://#diff-154919a44ba0f2c51e52e304d762cfea984055f106f73a189218f615fc3f3677L70-R125)`, `[[2]](diffhunk://#diff-81977a483e14dab667ef4659f136c7d53d50ccea13eed14574a57944000e9319L55-R137)`)

**Generator and Tree Traversal Refactoring:**

* Refactored the code generation logic to use the new tree structure for nested columns, replacing the old `MapToNodeTree` and `TraverseTree` functions with `ConvertNestedMapToNodeTree` and `TraverseTreeModel`. This streamlines nested struct generation and aligns with the new schema representation. (`[[1]](diffhunk://#diff-93b5439df693e891da6c7aef54a4dfc3bd2f00a0aab7cc4d352345ce3c3c4981L106-R118)`, `[[2]](diffhunk://#diff-93b5439df693e891da6c7aef54a4dfc3bd2f00a0aab7cc4d352345ce3c3c4981L127-R134)`, `[[3]](diffhunk://#diff-93b5439df693e891da6c7aef54a4dfc3bd2f00a0aab7cc4d352345ce3c3c4981L207-R159)`)
* Removed unnecessary imports (such as `sync`) from the generator where concurrency is no longer used for tree construction. (`[internal/generator/generator.goL8](diffhunk://#diff-93b5439df693e891da6c7aef54a4dfc3bd2f00a0aab7cc4d352345ce3c3c4981L8)`)

**Data Structures Enhancements:**

* Added a `Hidden` boolean field to the `Node` struct to track visibility, supporting the new schema metadata. (`[internal/datastructures/tree.goR10-R11](diffhunk://#diff-1199aed647a1398b399580cc12680d5bc205f9f2a23e26c5d7034092422a04b6R10-R11)`)

**Test Data Updates:**

* Updated `data.json` and `user_profile.json` to provide richer field metadata and to match the new nested schema format, ensuring tests reflect the new parsing and generation logic. (`[[1]](diffhunk://#diff-154919a44ba0f2c51e52e304d762cfea984055f106f73a189218f615fc3f3677R12-R15)`, `[[2]](diffhunk://#diff-154919a44ba0f2c51e52e304d762cfea984055f106f73a189218f615fc3f3677L60-R64)`, `[[3]](diffhunk://#diff-154919a44ba0f2c51e52e304d762cfea984055f106f73a189218f615fc3f3677L70-R125)`, `[[4]](diffhunk://#diff-81977a483e14dab667ef4659f136c7d53d50ccea13eed14574a57944000e9319L55-R137)`)